### PR TITLE
Fixed scoping problem for global declarations

### DIFF
--- a/Pharo/PharoJsBridgeTest/PjLoadingTest.class.st
+++ b/Pharo/PharoJsBridgeTest/PjLoadingTest.class.st
@@ -49,7 +49,6 @@ PjLoadingTest >> testLoadClassContents [
 	className := PjLoadForTest nameToUseForJsConversion.
 	PjLoadForTest reset.
 	first := self bridge convertToJs: PjLoadForTest.
-	self assert: (first beginsWith: 'function ' , className).
 	self assert: (first trim endsWith: className , '.', PjTranspiler pharoJsSelectorPrefix, 'initialize();').
 	firstBlock := self bridge
 		convertToJs: [ PjLoadForTest fortyTwo ] asValuedBlock.

--- a/Pharo/PharoJsCoreLibraries/PjBoolean.class.st
+++ b/Pharo/PharoJsCoreLibraries/PjBoolean.class.st
@@ -55,6 +55,7 @@ PjBoolean >> asBit [
 { #category : #converting }
 PjBoolean >> asJsObject [
 	"We want primitive booleans and not boxed ones!"
+	"This is necessary because if a value like true is sent as a message, then it is wrapped, so returning this doesn’t do the right thing. so the block [ false not == true ] will return false."
 	<javascript: 'return this == true'>
 ]
 

--- a/Pharo/PharoJsExporter/PjApplication.extension.st
+++ b/Pharo/PharoJsExporter/PjApplication.extension.st
@@ -25,9 +25,9 @@ PjApplication class >> appFullJsFileName [
 PjApplication class >> appFullJsFolderPath [
 	<pharoJsSkip>
 	self appJsSubFolder ifNotNil: [: subfolder|
-		^self appFullHtmlFolderPath / subfolder 
+		^self appFolder / subfolder 
 	].
-	^self appFullHtmlFolderPath
+	^self appFolder
 
 ]
 

--- a/Pharo/PharoJsExporter/PjExporterTest.class.st
+++ b/Pharo/PharoJsExporter/PjExporterTest.class.st
@@ -53,7 +53,6 @@ PjExporterTest >> testClassInheritanceOrder [
 PjExporterTest >> testCoreClassedLoaded [
 	exporter appClass: PjApplication.
 	jsCode := exporter javascriptCode.
-	self assert: (jsCode includesSubstring: 'function PjApplication(){}' ).
 	self deny: (jsCode includesSubstring: 'function Object()' ).
 	self assert: (jsCode includes: 'Object.__proto__.$def(function ', PjTranspiler pharoJsSelectorPrefix, 'new' before: 'PjApplication' ).
 	self deny: (jsCode includes: 'PjApplication' before: 'Object.__proto__.$def(function pj_new' ).

--- a/Pharo/PharoJsTranspiler/PjTranspiler.class.st
+++ b/Pharo/PharoJsTranspiler/PjTranspiler.class.st
@@ -111,8 +111,6 @@ PjTranspiler >> convertAllClasses: classes [
 	| actualClassesToConvert classesInWriteOrder |
 	beforeCodeOutputHook ifNotNil: [ beforeCodeOutputHook value ].
 	actualClassesToConvert := classes collect: #classToUseForJsConversion.
-	actualClassesToConvert asIdentitySet
-		do: [ :aClass | self writeClassDefinitionOf: aClass ].
 	classesInWriteOrder := self orderForWriting: actualClassesToConvert.
 	classesInWriteOrder
 		do: [ :aClass | 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,20 @@ Metacello new
 </pre>
 
 More doc is available at: http://pharojs.org/
+
+## Installing from source code
+Clone the following repositories to your local machine:
+```
+https://github.com/bouraqadi/PharoMisc
+https://github.com/svenvc/zinc
+https://github.com/bouraqadi/PharoJS
+```
+* In Pharo, open Iceberg `Cmd+O+I`
+* Add -> Import from existing clone -> locate PharoMisc
+* Open PharoMisc from Iceberg and add the packages `PharoExtra`, `LightweightObserver`, and `Equals`
+* Add -> Import from existing clone -> locate zinc
+* Open zinc from Iceberg and add the package `Zinc-WebSocket-Core`
+* Finally, Add -> Import from existing clone -> locate PharoJS
+* Open PharoJS from Iceberg and add all packages
+    * Note: Initially, some packages might be green, indicating that changes have been made
+    * This can be resolved by re-loading them in some particular order until they're all up to date

--- a/README.md
+++ b/README.md
@@ -10,20 +10,3 @@ Metacello new
 </pre>
 
 More doc is available at: http://pharojs.org/
-
-## Installing from source code
-Clone the following repositories to your local machine:
-```
-https://github.com/bouraqadi/PharoMisc
-https://github.com/svenvc/zinc
-https://github.com/bouraqadi/PharoJS
-```
-* In Pharo, open Iceberg `Cmd+O+I`
-* Add -> Import from existing clone -> locate PharoMisc
-* Open PharoMisc from Iceberg and add the packages `PharoExtra`, `LightweightObserver`, and `Equals`
-* Add -> Import from existing clone -> locate zinc
-* Open zinc from Iceberg and add the package `Zinc-WebSocket-Core`
-* Finally, Add -> Import from existing clone -> locate PharoJS
-* Open PharoJS from Iceberg and add all packages
-    * Note: Initially, some packages might be green, indicating that changes have been made
-    * This can be resolved by re-loading them in some particular order until they're all up to date


### PR DESCRIPTION
There was a bug where functions were being overwritten by blank
declarations from PjTranspiler. All of the functions were declared in
the local scope, which takes precedence over the global scope. So when
we tried to make a subclass with pj_makeSubclass, this refers to the
empty function. If it tries to push to this.subclasses, it errors out
as this.subclasses is undefined.

It's fixed by removing the code in PjTranspiler that makes these 
declarations.

Some of the redundant declarations that were removed include:
function ZeroDivide(){};
function Margin(){};
function PjUndefinedObject(){};
function LoSubjectSet(){};